### PR TITLE
Enable dotnet build (#65)

### DIFF
--- a/SysBot.Pokemon.ConsoleApp/SysBot.Pokemon.ConsoleApp.csproj
+++ b/SysBot.Pokemon.ConsoleApp/SysBot.Pokemon.ConsoleApp.csproj
@@ -10,12 +10,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <ProjectReference Include="..\SysBot.Pokemon.Discord\SysBot.Pokemon.Discord.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Twitch\SysBot.Pokemon.Twitch.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Z3\SysBot.Pokemon.Z3.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(Configuration)' == 'Release' ">
+    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="Fody" Version="6.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
+++ b/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
@@ -16,12 +16,13 @@
     <Version>01.00.00</Version>
     <Nullable>enable</Nullable>
     <Platforms>x64;x86</Platforms>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PKHeX.Core" Version="20.4.14" />
-    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,14 @@
     <ProjectReference Include="..\SysBot.Pokemon.Twitch\SysBot.Pokemon.Twitch.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Z3\SysBot.Pokemon.Z3.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(Configuration)' == 'Release' ">
+    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="Fody" Version="6.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
+++ b/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
@@ -1,25 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="PKHeX.Core" Version="20.4.14" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
   </ItemGroup>
 
-  <!-- x64 specific references -->
-  <ItemGroup Condition=" '$(Platform)' == 'x64' ">
-    <PackageReference Include="Microsoft.Z3.x64" Version="4.8.7" />
-  </ItemGroup>
-
-  <!-- x86 specific references -->
-  <ItemGroup Condition=" '$(Platform)' == 'x86' ">
-    <PackageReference Include="Microsoft.Z3.x86" Version="4.8.7" />
-  </ItemGroup>
+  <Choose>
+    
+    <When Condition=" '$(Platform)' == 'x64' OR $(RuntimeIdentifier.EndsWith('x64')) ">
+      <!-- x64 specific references -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Z3.x64" Version="4.8.7" />
+      </ItemGroup>
+    </When>
+    
+    <Otherwise>
+      <!-- x86 specific references -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Z3.x86" Version="4.8.7" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
 </Project>


### PR DESCRIPTION
* Enable dotnet build (#64)

Always specify GenerateResourceUsePreserializedResources=true
Always reference System.Resources.Extensions
Load Fody only for net47 build, in release configuration

* Include Microsoft.Z3 even when Platform is not strictly 'x64'